### PR TITLE
Add phpcs exclusion for PHP8+

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -24,6 +24,10 @@ rm -f build/plugin-check/**/.DS_Store
 # Remove the bash check in the plugin scan (doesn't work locally for me)
 sed -i '8,14d' 'build/plugin-check/bin/plugin-scan/plugin-scan.sh'
 
+# Add an exclusion for PHP 8+ to the plugin-scan phpcs.xml file at line 32
+sed -i '32i\
+<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />' bin/plugin-scan/plugin-scan.sh.xml
+
 chmod +x build/plugin-check/bin/plugin-scan/plugin-scan.sh
 chmod +x build/plugin-check/bin/plugin-scan/plugin-scan.sh.ignore
 chmod +x build/plugin-check/bin/plugin-scan/plugin-scan.sh.xml

--- a/bin/update-submodules.sh
+++ b/bin/update-submodules.sh
@@ -8,3 +8,7 @@ chmod +x bin/plugin-scan/plugin-scan.sh.xml
 
 # Remove the bash check in the plugin scan (doesn't work locally for me)
 sed -i '8,14d' 'bin/plugin-scan/plugin-scan.sh'
+
+# Add an exclusion for PHP 8+ to the plugin-scan phpcs.xml file at line 32
+sed -i '32i\
+<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />' bin/plugin-scan/plugin-scan.sh.xml


### PR DESCRIPTION
Adds the following into the `phpcs.xml` config file so the checks run on PHP 8+:
`<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />`

See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035